### PR TITLE
'feat/take_home_test_canonical_carles_sole_grau' to 'main'

### DIFF
--- a/REPORT.md
+++ b/REPORT.md
@@ -326,7 +326,27 @@ selrac@carles-evert hello_ppa/hello-2.10 (feat/take_home_test_canonical_carles_s
 
 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
 ```
+## 8. Paste the executing result of  'dpkg -S testing.sh; testing.sh'
 
+### Full output: dpkg -S testing.sh; testing.sh 
+
+```bash
+selrac@carles-evert hello_ppa/hello-2.10 (feat/take_home_test_canonical_carles_sole_grau) » dpkg -S testing.sh; testing.sh             
+hello: /usr/bin/testing.sh
+this is a test from Carles Solé Grau
+```
+
+### STDOUT: dpkg -S testing.sh 2> /dev/null; testing.sh 2> /dev/null
+```bash
+selrac@carles-evert hello_ppa/hello-2.10 (feat/take_home_test_canonical_carles_sole_grau) » dpkg -S testing.sh 2> /dev/null; testing.sh 2> /dev/null
+hello: /usr/bin/testing.sh
+```
+
+### STDERR: dpkg -S testing.sh > /dev/null; testing.sh > /dev/null
+```bash
+selrac@carles-evert hello_ppa/hello-2.10 (feat/take_home_test_canonical_carles_sole_grau) » dpkg -S testing.sh > /dev/null; testing.sh > /dev/null
+this is a test from Carles Solé Grau
+```
 
 
 

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,49 +1,44 @@
 # Take Home Test from Canonical - Carles Solé Grau
 
-## TO REMOVE
 
-```bash
-sudo apt install devscripts
-sudo apt install build-essential devscripts debhelper
-```
+An initial general reading of this tutorial helps to understand all the necessary steps to generate and publish a package to Launchpad PPA:
+- [Minimum Complete Example of Debian Packaging and Launchpad PPA (hellodeb)](https://metebalci.com/blog/a-minimum-complete-example-of-debian-packaging-and-launchpad-ppa-hellodeb/)
 
-Reference:
-[Minimum Complete Example of Debian Packaging and Launchpad PPA (hellodeb)](https://metebalci.com/blog/a-minimum-complete-example-of-debian-packaging-and-launchpad-ppa-hellodeb/)
-
-## TO REMOVE
+---
 
 Pick an existing Debian package from the Ubuntu archive. The selected package should be simple and easy to work with.
 
 ## 1. Download the source code of that Debian package
 
-Go to [Ubuntu Packages](https://packages.ubuntu.com/) and select your desired Ubuntu version.
-In my case: [Plucky](https://packages.ubuntu.com/plucky/).
+1. Go to [Ubuntu Packages](https://packages.ubuntu.com/) and select your desired Ubuntu version.  
+    I am working on Ubuntu 25.4: [Plucky](https://packages.ubuntu.com/plucky/).
 
-Choose a simple package to avoid overcomplicating the exercise.
+2. Choose a simple package to avoid overcomplicating the exercise.  
+    [hello](https://packages.ubuntu.com/plucky/hello) is a good choice because it is an example package based on GNU Hello.
+    It is also the one used in [the reference link](https://pastebin.ubuntu.com/p/hZ4sH647Jt/).
 
-I selected [hello](https://packages.ubuntu.com/plucky/hello) because it is an example package based on GNU Hello.
-It is also the one used in [the reference link](https://pastebin.ubuntu.com/p/hZ4sH647Jt/).
+3. In the **Download** section, select your target architecture to get instructions for downloading the package:
+    - [https://packages.ubuntu.com/plucky/amd64/hello/download](https://packages.ubuntu.com/plucky/amd64/hello/download)
 
-In the **Download** section, select your target architecture to get instructions for downloading the package:
-[https://packages.ubuntu.com/plucky/amd64/hello/download](https://packages.ubuntu.com/plucky/amd64/hello/download)
+4. Get the source code:
 
-There are multiple ways to get the source code of a package:
-- [Get the source of a package](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/how-to/get-package-source/): Link provided in the test assignment instructions.
-- [apt-src](https://manpages.ubuntu.com/manpages/plucky/man1/apt-src.1p.html)
-- [How to get source code of package using the apt command on Debian or Ubuntu](https://www.cyberciti.biz/faq/how-to-get-source-code-of-package-using-the-apt-command-on-debian-or-ubuntu/)
+    There are multiple ways to get the source code of a package:
+    - [Get the source of a package](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/how-to/get-package-source/): Link provided in the test assignment instructions.
+    - [apt-src](https://manpages.ubuntu.com/manpages/plucky/man1/apt-src.1p.html)
+    - [How to get source code of package using the apt command on Debian or Ubuntu](https://www.cyberciti.biz/faq/how-to-get-source-code-of-package-using-the-apt-command-on-debian-or-ubuntu/)
 
-Feel free to use the method you are most comfortable with.
-For this exercise, I will use [pull-pkg](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/how-to/get-package-source/#pull-pkg), as described in the official guide. It is one of the simplest and fastest methods.
+    Feel free to use the method you are most comfortable with.  
+    For this exercise, I will use [pull-pkg](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/how-to/get-package-source/#pull-pkg), as described in the official guide.  
 
-```bash
-sudo apt update && sudo apt install ubuntu-dev-tools
-```
+    It is one of the simplest and fastest methods.
+    ```bash
+    sudo apt update && sudo apt install ubuntu-dev-tools
+    ```
 
-Then fetch the source:
-
-```bash
-pull-lp-source hello
-```
+    Then fetch the source:
+    ```bash
+    pull-lp-source hello
+    ```
 
 ### Initialize Git repository
 
@@ -64,67 +59,66 @@ This script must output the following message to **standard error (STDERR)** whe
 this is a test from Carles Solé Grau
 ```
 
-Create a `testing.sh` file and place it in the `debian` directory.  
-This is because the `debian/` directory is the standard location recognized by the Debian packaging system for defining what gets installed, where, and how. See: [Debian Policy Manual – Source Packages](https://www.debian.org/doc/debian-policy/ch-source.html)
+1. Create a `testing.sh` file and place it in the `debian` directory.
 
-Content of `debian/testing.sh`:
+    This is because the `debian/` directory is the standard location recognized by the Debian packaging system for defining what gets installed, where, and how. See: [Debian Policy Manual – Source Packages](https://www.debian.org/doc/debian-policy/ch-source.html)  
+    Content of `debian/testing.sh`:
 
-```bash
-#!/bin/bash
+    ```bash
+    #!/bin/bash
 
-# Use '>&2' to redirect output to STDERR
-echo "this is a test from Carles Solé Grau" >&2
-```
+    # Use '>&2' to redirect output to STDERR
+    echo "this is a test from Carles Solé Grau" >&2
+    ```
 
-Make the script executable:
+2. Make the script executable:
 
-```bash
-chmod +x debian/testing.sh
-```
+    ```bash
+    chmod +x debian/testing.sh
+    ```
 
-To verify the message goes to STDERR:
+3. Verify the message goes to STDERR:
 
-```bash
-debian/testing.sh > stdout.txt 2> stderr.txt
-```
+    ```bash
+    debian/testing.sh > stdout.txt 2> stderr.txt
+    ```
 
-Then check `stderr.txt` to confirm the output.  
-Don't forget to delete the temporary files after testing.
+    Then check `stderr.txt` to confirm the output.  
+    Don't forget to delete the temporary files after testing.
 
-To install this script on your system when installing the `.deb` package, add/edit the file `debian/install` with this line:
+4. To install this script on your system when installing the `.deb` package, add/edit the file `debian/install` with this line:
 
-```
-debian/testing.sh /usr/bin
-```
-`/usr/bin` has been used as the installation path because the [reference example link provided](https://pastebin.ubuntu.com/p/hZ4sH647Jt/) also points to this location.
+    ```
+    debian/testing.sh /usr/bin
+    ```
+    `/usr/bin` has been used as the installation path because the [reference example link provided](https://pastebin.ubuntu.com/p/hZ4sH647Jt/) also points to this location.
 
 ## 3. Echo a string during the Debian package installation via STDOUT
 
-This message must be printed to **standard output (STDOUT)**, so `debian/testing.sh`. can not be reused.
+This message must be printed to **standard output (STDOUT)**, so `debian/testing.sh` can not be reused.
 
-To do this, create a [maintainer script](https://www.debian.org/doc/debian-policy/ch-binary.html#prompting-in-maintainer-scripts) that runs during installation.  
-We will use the `postinst` script, which is executed after the package is installed.
-
+1. Create a [maintainer script](https://www.debian.org/doc/debian-policy/ch-binary.html#prompting-in-maintainer-scripts) that runs during installation.  
+We will use the `postinst` script, which is executed after the package is installed.  
 Create or edit `debian/postinst`:
 
-```bash
-#!/bin/bash
-set -e
+    ```bash
+    #!/bin/bash
+    set -e
 
-# Output to STDOUT
-echo "this is a test from Carles Solé Grau"
+    # Output to STDOUT
+    echo "this is a test from Carles Solé Grau"
 
-# Hook for debhelper (even if not required) to avoid a warning
-#DEBHELPER#
+    # Hook for debhelper (even if not required) to avoid a warning
+    #DEBHELPER#
 
-exit 0
-```
+    exit 0
+    ```
 
-Make it executable:
+2. Make it executable:
 
-```bash
-chmod +x debian/postinst
-```
+    ```bash
+    chmod +x debian/postinst
+    ```
 
 ### Validate the prompt during installation
 
@@ -132,49 +126,126 @@ Before proceeding and pushing all this code to the Launchpad PPA, it is a good i
 
 Build the `.deb` package following [Ubuntu - Build packages](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/how-to/build-packages/)
 
-Install the prerequisites:
-```bash
-sudo apt update
-sudo apt install sbuild debhelper ubuntu-dev-tools piuparts
-```
-Since we just want to test the .deb package locally, we can use:
-```
-sbuild -c <RELEASE>-<ARCH>[-shm]
-```
-However, I had some issues with this tool, so I ended up using `debuild` instead:
-```
-debuild -us -uc 
-```
+1. Install the prerequisites:
+    ```bash
+    sudo apt update
+    sudo apt install sbuild debhelper ubuntu-dev-tools piuparts
+    ```
+2. Since we just want to test the .deb package locally, we can use:
+    ```
+    sbuild -c <RELEASE>-<ARCH>[-shm]
+    ```
+    However, I had some issues with this tool, so I ended up using `debuild` instead:
+    - [debuild - build a Debian package](https://manpages.ubuntu.com/manpages/plucky/en/man1/debuild.1.html)
+    - [debuild - build a Debian package - Examples](https://manpages.ubuntu.com/manpages/plucky/en/man1/debuild.1.html#examples)
 
-Before running it, make sure `help2man` is installed on your system:
-```
-sudo apt update
-sudo apt install help2man
-```
+    ```
+    debuild -i -us -uc -b
+    ```
+    `-us`and `-uc` to avoid signing sources and changes.
 
-If everything goes well, a `.deb` file should be generated one directory up. To test the installation:
+    Before running it, make sure `help2man` is installed on your system:
+    ```
+    sudo apt update
+    sudo apt install help2man
+    ```
 
-```bash
-sudo dpkg -i ../hello_2.10-*.deb
-```
+If everything goes well, a `.deb` file should be generated one directory up.
 
-You should see the following printed in the terminal:
-`/usr/bin` has been used as in the installation path as the [reference example link provided](https://pastebin.ubuntu.com/p/hZ4sH647Jt/) points also there.
-```
-this is a test from Carles Solé Grau
-```
+3. Test the installation:
 
-After installation run:
-```
-dpkg -S testing.sh; testing.sh
-```
+    ```bash
+    sudo dpkg -i ../hello_2.10-*.deb
+    ```
 
-Outuput should look like:
-```
-hello: /usr/bin/testing.sh
-this is a test from Carles Solé Grau
-```
+    You should see the following printed in the terminal:
+    `/usr/bin` has been used as in the installation path as the [reference example link provided](https://pastebin.ubuntu.com/p/hZ4sH647Jt/) points also there.
+    ```
+    this is a test from Carles Solé Grau
+    ```
+
+4. After installation run:
+    ```
+    dpkg -S testing.sh; testing.sh
+    ```
+
+    Outuput should look like:
+    ```
+    hello: /usr/bin/testing.sh
+    this is a test from Carles Solé Grau
+    ```
 
 ## 4. Push all your changes to a public Git repository (e.g. Launchpad Git, GitHub, or GitLab)
 
 Choose your preferred Git provider and push all your changes there.
+
+## 5. Upload (dput) the source change to your PPA on the Launchpad
+
+The provided links:
+- https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/how-to/upload-packages-to-ppa/
+- https://github.com/canonical/ubuntu-packaging-guide/blob/2.0-preview/docs/how-to/upload-packages-to-ppa.rst
+
+It appears that the official documentation page for uploading a package to a Launchpad PPA is still under construction.
+Therefore, we have followed the necessary steps using various resources found online.
+
+### Update changelog
+
+- [The Launchpad PPA - launchpad-dependencies](https://documentation.ubuntu.com/launchpad/en/latest/developer/explanation/launchpad-ppa/#launchpad-dependencies): Step 4.
+- [debchange - Tool for maintenance of the debian/changelog file in a source package](https://manpages.ubuntu.com/manpages/trusty/man1/debchange.1.html)
+
+The first step is to add a new entry to the `debian/changelog`. You can do this manually or use the [dch](https://manpages.ubuntu.com/manpages/trusty/man1/debchange.1.html) tool:
+```
+dch -i
+```
+
+Add an entry like this:
+```
+hello (2.10-5selracnoble1) noble; urgency=medium
+
+    * Install 'testing.sh' in '/usr/bin' and print a prompt message to STDOUT during installation
+
+ -- Carles Sole Grau <carlessg11@gmail.com>  Sat, 26 Jul 2025 21:59:05 +0200
+```
+
+The third column specifies which Ubuntu version the package is intended to be built for.
+
+### Build source package
+To upload the source changes to the Launchpad PPA, you need to generate and sign them:
+
+- [WiKi Ubuntu - UbuntuDevelopment - Uploading](https://wiki.ubuntu.com/UbuntuDevelopment/Uploading): "In order for your upload to be accepted by the archive maintenance software it must be signed by a GPG key that is associated with a launchpad account that has upload rights for the package."
+- [Ubuntu Mantainers Handbook - PackageBuilding ](https://github.com/canonical/ubuntu-maintainers-handbook/blob/main/PackageBuilding.md): "In order for a source package to be accepted by Launchpad, it must be signed"
+
+You can follow the steps described in [Using GPG to manage OpenPGP keys](https://documentation.ubuntu.com/launchpad/en/latest/user/how-to/import-openpgp-key/#using-gpg-to-manage-openpgp-keys) to generate GPG keys and link them to your personal Launchpad account.
+
+Now you can build a signed source package:
+- [Building with debuild](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/how-to/build-packages/#building-with-debuild)
+- [debuild - build a Debian package](https://manpages.ubuntu.com/manpages/plucky/en/man1/debuild.1.html)
+
+```bash
+debuild -S -sa -k"<YOUR-GPG-KEY-ID>"
+```
+Replace `<YOUR-GPG-KEY-ID>` with your GPG key identifier (you can find it with `gpg --list-keys`).  
+This command generates the source package and signs it with your key, leaving the files ready to be uploaded to the Launchpad PPA.
+
+
+### Upload the changes
+Follow this guide to upload the source changes: [Upload a package to a PPA](https://documentation.ubuntu.com/launchpad/en/latest/user/how-to/packaging/ppa-package-upload/).
+
+In my case, I chose the [Upload a package to a PPA - FTP](https://documentation.ubuntu.com/launchpad/en/latest/user/how-to/packaging/ppa-package-upload/#ftp) method:
+
+Example `~/.dput.cf` configuration:
+```
+[selrac-packaging-training]
+fqdn = ppa.launchpad.net
+method = ftp
+incoming = ~selrac/packaging-training
+login = anonymous
+allow_unsigned_uploads = 0
+```
+Then simply run:
+```
+dput selrac-packaging-training ../hello_2.10-5ubuntuplucky2_source.changes
+```
+
+After a short while, you should see a new Published Package appear in your Launchpad PPA.
+

--- a/REPORT.md
+++ b/REPORT.md
@@ -265,4 +265,68 @@ After this, a new entry/file will be generated in `/etc/apt/sources.list.d/`
 sudo apt install hello
 ```
 
+## 7. Paste the message printed during the installation via standard out (STDOUT)
+
+After each `install`, run:
+```bash
+sudo apt remove hello
+```
+This allows you to perform a complete installation each time.
+
+### Full output: sudo apt install hello
+
+```bash
+selrac@carles-evert hello_ppa/hello-2.10 (feat/take_home_test_canonical_carles_sole_grau) » sudo apt install hello
+Installing:                     
+  hello
+
+Summary:
+  Upgrading: 0, Installing: 1, Removing: 0, Not Upgrading: 0
+  Download size: 49,4 kB
+  Space needed: 276 kB / 226 GB available
+
+Get:1 https://ppa.launchpadcontent.net/selrac/packaging-training/ubuntu plucky/main amd64 hello amd64 2.10-5ubuntuplucky2 [49,4 kB]
+Fetched 49,4 kB in 0s (199 kB/s) 
+Selecting previously unselected package hello.
+(Reading database ... 342128 files and directories currently installed.)
+Preparing to unpack .../hello_2.10-5ubuntuplucky2_amd64.deb ...
+Unpacking hello (2.10-5ubuntuplucky2) ...
+Setting up hello (2.10-5ubuntuplucky2) ...
+this is a test from Carles Solé Grau
+Processing triggers for man-db (2.13.0-1) ...
+Processing triggers for install-info (7.1.1-1) ...
+```
+
+### STDOUT: sudo apt install hello 2> /dev/null
+```bash
+selrac@carles-evert hello_ppa/hello-2.10 (feat/take_home_test_canonical_carles_sole_grau) » sudo apt install hello 2> /dev/null 
+Installing:                     
+  hello
+
+Summary:
+  Upgrading: 0, Installing: 1, Removing: 0, Not Upgrading: 0
+  Download size: 49,4 kB
+  Space needed: 276 kB / 226 GB available
+
+Get:1 https://ppa.launchpadcontent.net/selrac/packaging-training/ubuntu plucky/main amd64 hello amd64 2.10-5ubuntuplucky2 [49,4 kB]
+Fetched 49,4 kB in 0s (202 kB/s) 
+Selecting previously unselected package hello.
+(Reading database ... 342128 files and directories currently installed.)
+Preparing to unpack .../hello_2.10-5ubuntuplucky2_amd64.deb ...
+Unpacking hello (2.10-5ubuntuplucky2) ...
+Setting up hello (2.10-5ubuntuplucky2) ...
+this is a test from Carles Solé Grau
+Processing triggers for man-db (2.13.0-1) ...
+Processing triggers for install-info (7.1.1-1) ...
+```
+
+### STDERR: sudo apt install hello > /dev/null
+```bash
+selrac@carles-evert hello_ppa/hello-2.10 (feat/take_home_test_canonical_carles_sole_grau) » sudo apt install hello > /dev/null
+
+WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
+```
+
+
+
 

--- a/REPORT.md
+++ b/REPORT.md
@@ -57,3 +57,31 @@ git init
 ```
 
 From now on, try to commit each step individually for easier tracking and review.
+
+## 2. Add an executable bash script called "testing.sh"
+
+This script must output the following message to **standard error (STDERR)** when executed:
+
+```
+this is a test from Carles Solé Grau
+```
+
+Create a `testing.sh` file and place it in `debian` directory.
+This is because the `debian/` directory is the only location explicitly recognized by the Debian packaging system for defining what gets installed, where, and how: [Debian Policy Manual – Source Packages](https://www.debian.org/doc/debian-policy/ch-source.html)
+
+Add the following content to the script:
+
+```
+#!/bin/bash
+
+# Use '>&2' to redirect output to STDERR
+echo "this is a test from Carles Solé Grau" >&2
+```
+
+To verify that the message is correctly printed to STDERR, run the following command:
+```
+./debian/testing.sh > stdout.txt 2> stderr.txt
+```
+
+Then inspect the contents of stderr.txt to confirm the message was redirected properly.
+Remember to delete the temporary files (stdout.txt and stderr.txt) once you're done testing.

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,5 +1,12 @@
 # Take Home Test from Canonical - Carles Solé Grau
 
+# 1. Git Repository
+- https://github.com/carlessole/hello_ppa_training.git
+
+# 2. Launchpad PPA
+- https://launchpad.net/~selrac/+archive/ubuntu/packaging-training
+
+# 3.Reference Guide
 
 An initial general reading of this tutorial helps to understand all the necessary steps to generate and publish a package to Launchpad PPA:
 - [Minimum Complete Example of Debian Packaging and Launchpad PPA (hellodeb)](https://metebalci.com/blog/a-minimum-complete-example-of-debian-packaging-and-launchpad-ppa-hellodeb/)
@@ -326,7 +333,7 @@ selrac@carles-evert hello_ppa/hello-2.10 (feat/take_home_test_canonical_carles_s
 
 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
 ```
-## 8. Paste the executing result of  'dpkg -S testing.sh; testing.sh'
+## 8. Paste the executing result of 'dpkg -S testing.sh; testing.sh'
 
 ### Full output: dpkg -S testing.sh; testing.sh 
 
@@ -345,6 +352,39 @@ hello: /usr/bin/testing.sh
 ### STDERR: dpkg -S testing.sh > /dev/null; testing.sh > /dev/null
 ```bash
 selrac@carles-evert hello_ppa/hello-2.10 (feat/take_home_test_canonical_carles_sole_grau) » dpkg -S testing.sh > /dev/null; testing.sh > /dev/null
+this is a test from Carles Solé Grau
+```
+
+# 4. Output of the installation and testing.sh
+
+For more detailed output please take a look on:
+- [7. Paste the message printed during the installation via standard out (STDOUT)](#7-paste-the-message-printed-during-the-installation-via-standard-out-stdout)
+- [8. Paste the executing result of 'dpkg -S testing.sh; testing.sh'](#8-paste-the-executing-result-of-dpkg--s-testingsh-testingsh)
+
+Based on the [reference output link](https://pastebin.ubuntu.com/p/hZ4sH647Jt/):
+
+```bash
+selrac@carles-evert hello_ppa/hello-2.10 (feat/take_home_test_canonical_carles_sole_grau) » sudo apt install hello        
+Installing:                     
+  hello
+
+Summary:
+  Upgrading: 0, Installing: 1, Removing: 0, Not Upgrading: 0
+  Download size: 49,4 kB
+  Space needed: 276 kB / 226 GB available
+
+Get:1 https://ppa.launchpadcontent.net/selrac/packaging-training/ubuntu plucky/main amd64 hello amd64 2.10-5ubuntuplucky2 [49,4 kB]
+Fetched 49,4 kB in 0s (252 kB/s) 
+Selecting previously unselected package hello.
+(Reading database ... 342128 files and directories currently installed.)
+Preparing to unpack .../hello_2.10-5ubuntuplucky2_amd64.deb ...
+Unpacking hello (2.10-5ubuntuplucky2) ...
+Setting up hello (2.10-5ubuntuplucky2) ...
+this is a test from Carles Solé Grau
+Processing triggers for man-db (2.13.0-1) ...
+Processing triggers for install-info (7.1.1-1) ...
+selrac@carles-evert hello_ppa/hello-2.10 (feat/take_home_test_canonical_carles_sole_grau) » dpkg -S testing.sh; testing.sh
+hello: /usr/bin/testing.sh
 this is a test from Carles Solé Grau
 ```
 

--- a/REPORT.md
+++ b/REPORT.md
@@ -174,3 +174,7 @@ Outuput should look like:
 hello: /usr/bin/testing.sh
 this is a test from Carles Solé Grau
 ```
+
+## 4. Push all your changes to a public Git repository (e.g. Launchpad Git, GitHub, or GitLab)
+
+Choose your preferred Git provider and push all your changes there.

--- a/REPORT.md
+++ b/REPORT.md
@@ -139,13 +139,13 @@ Build the `.deb` package following [Ubuntu - Build packages](https://canonical-u
     - [debuild - build a Debian package](https://manpages.ubuntu.com/manpages/plucky/en/man1/debuild.1.html)
     - [debuild - build a Debian package - Examples](https://manpages.ubuntu.com/manpages/plucky/en/man1/debuild.1.html#examples)
 
-    ```
+    ```bash
     debuild -i -us -uc -b
     ```
     `-us`and `-uc` to avoid signing sources and changes.
 
     Before running it, make sure `help2man` is installed on your system:
-    ```
+    ```bash
     sudo apt update
     sudo apt install help2man
     ```
@@ -160,17 +160,17 @@ If everything goes well, a `.deb` file should be generated one directory up.
 
     You should see the following printed in the terminal:
     `/usr/bin` has been used as in the installation path as the [reference example link provided](https://pastebin.ubuntu.com/p/hZ4sH647Jt/) points also there.
-    ```
+    ```bash
     this is a test from Carles Solé Grau
     ```
 
 4. After installation run:
-    ```
+    ```bash
     dpkg -S testing.sh; testing.sh
     ```
 
     Outuput should look like:
-    ```
+    ```bash
     hello: /usr/bin/testing.sh
     this is a test from Carles Solé Grau
     ```
@@ -194,7 +194,7 @@ Therefore, we have followed the necessary steps using various resources found on
 - [debchange - Tool for maintenance of the debian/changelog file in a source package](https://manpages.ubuntu.com/manpages/trusty/man1/debchange.1.html)
 
 The first step is to add a new entry to the `debian/changelog`. You can do this manually or use the [dch](https://manpages.ubuntu.com/manpages/trusty/man1/debchange.1.html) tool:
-```
+```bash
 dch -i
 ```
 
@@ -243,9 +243,26 @@ login = anonymous
 allow_unsigned_uploads = 0
 ```
 Then simply run:
-```
+```bash
 dput selrac-packaging-training ../hello_2.10-5ubuntuplucky2_source.changes
 ```
 
 After a short while, you should see a new Published Package appear in your Launchpad PPA.
+
+## 6. Install your package from your PPA
+In your Launchpad PPA, under the `Adding this PPA to your system` section, you will find the commands needed to add this PPA to your system.
+You can also read more about it in this guide:
+- [Add a Personal Package Archive (PPA)](https://help.ubuntu.com/stable/ubuntu-help/addremove-ppa.html.en)
+
+```bash
+sudo add-apt-repository ppa:selrac/packaging-training
+sudo apt update
+```
+
+After this, a new entry/file will be generated in `/etc/apt/sources.list.d/`
+
+```bash
+sudo apt install hello
+```
+
 

--- a/REPORT.md
+++ b/REPORT.md
@@ -18,7 +18,7 @@ Pick an existing Debian package from the Ubuntu archive. The selected package sh
 ## 1. Download the source code of that Debian package
 
 1. Go to [Ubuntu Packages](https://packages.ubuntu.com/) and select your desired Ubuntu version.  
-    I am working on Ubuntu 25.4: [Plucky](https://packages.ubuntu.com/plucky/).
+    If working on Ubuntu 25.04: [Plucky](https://packages.ubuntu.com/plucky/).
 
 2. Choose a simple package to avoid overcomplicating the exercise.  
     [hello](https://packages.ubuntu.com/plucky/hello) is a good choice because it is an example package based on GNU Hello.
@@ -35,7 +35,7 @@ Pick an existing Debian package from the Ubuntu archive. The selected package sh
     - [How to get source code of package using the apt command on Debian or Ubuntu](https://www.cyberciti.biz/faq/how-to-get-source-code-of-package-using-the-apt-command-on-debian-or-ubuntu/)
 
     Feel free to use the method you are most comfortable with.  
-    For this exercise, I will use [pull-pkg](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/how-to/get-package-source/#pull-pkg), as described in the official guide.  
+    For this exercise, [pull-pkg](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/how-to/get-package-source/#pull-pkg) is used, as described in the link provided in the test assignment.  
 
     It is one of the simplest and fastest methods.
     ```bash
@@ -68,7 +68,8 @@ this is a test from Carles Solé Grau
 
 1. Create a `testing.sh` file and place it in the `debian` directory.
 
-    This is because the `debian/` directory is the standard location recognized by the Debian packaging system for defining what gets installed, where, and how. See: [Debian Policy Manual – Source Packages](https://www.debian.org/doc/debian-policy/ch-source.html)  
+    This is because the `debian/` directory is the standard location recognized by the Debian packaging system for defining what gets installed, where, and how.  
+    See: [Debian Policy Manual – Source Packages](https://www.debian.org/doc/debian-policy/ch-source.html)  
     Content of `debian/testing.sh`:
 
     ```bash
@@ -91,7 +92,7 @@ this is a test from Carles Solé Grau
     ```
 
     Then check `stderr.txt` to confirm the output.  
-    Don't forget to delete the temporary files after testing.
+    Don't forget to delete these temporary files after testing.
 
 4. To install this script on your system when installing the `.deb` package, add/edit the file `debian/install` with this line:
 
@@ -105,7 +106,7 @@ this is a test from Carles Solé Grau
 This message must be printed to **standard output (STDOUT)**, so `debian/testing.sh` can not be reused.
 
 1. Create a [maintainer script](https://www.debian.org/doc/debian-policy/ch-binary.html#prompting-in-maintainer-scripts) that runs during installation.  
-We will use the `postinst` script, which is executed after the package is installed.  
+`postinst` script is the used one, which is executed after the package is installed.  
 Create or edit `debian/postinst`:
 
     ```bash
@@ -138,7 +139,7 @@ Build the `.deb` package following [Ubuntu - Build packages](https://canonical-u
     sudo apt update
     sudo apt install sbuild debhelper ubuntu-dev-tools piuparts
     ```
-2. Since we just want to test the .deb package locally, we can use:
+2. Since .deb package is testet just locally, we can use:
     ```
     sbuild -c <RELEASE>-<ARCH>[-shm]
     ```

--- a/REPORT.md
+++ b/REPORT.md
@@ -1,0 +1,59 @@
+# Take Home Test from Canonical - Carles Solé Grau
+
+## TO REMOVE
+
+```bash
+sudo apt install devscripts
+sudo apt install build-essential devscripts debhelper
+```
+
+Reference:
+[Minimum Complete Example of Debian Packaging and Launchpad PPA (hellodeb)](https://metebalci.com/blog/a-minimum-complete-example-of-debian-packaging-and-launchpad-ppa-hellodeb/)
+
+## TO REMOVE
+
+Pick one existing Debian package from the Ubuntu archive. The selected package should be simple and easy to work with.
+
+## 1. Download the source code of that Debian package
+
+Go to [Ubuntu Packages](https://packages.ubuntu.com/) and select the desired Ubuntu version.
+In my case: [Plucky](https://packages.ubuntu.com/plucky/).
+
+Choose a simple package to avoid overcomplicating the exercise.
+
+I selected [hello](https://packages.ubuntu.com/plucky/hello) because it is an example package based on GNU Hello.
+It is also the one used in [the reference link](https://pastebin.ubuntu.com/p/hZ4sH647Jt/).
+
+In the **Download** section, select your target architecture to get instructions for downloading the package:
+[https://packages.ubuntu.com/plucky/amd64/hello/download](https://packages.ubuntu.com/plucky/amd64/hello/download)
+
+There are multiple ways to get the source code of a package:
+- [Get the source of a package](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/how-to/get-package-source/): Link provided in the test assignment instructions.
+- [apt-src](https://manpages.ubuntu.com/manpages/plucky/man1/apt-src.1p.html)
+- [How to get source code of package using the apt command on Debian or Ubuntu](https://www.cyberciti.biz/faq/how-to-get-source-code-of-package-using-the-apt-command-on-debian-or-ubuntu/)
+
+Feel free to use the method you are most comfortable with.
+For this exercise, I will use [pull-pkg](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/how-to/get-package-source/#pull-pkg), as described in the guide provided in the test instructions. It is one of the simplest and fastest ways to achieve it.
+
+```bash
+sudo apt update && sudo apt install ubuntu-dev-tools
+```
+
+[pull-pkg](https://canonical-ubuntu-packaging-guide.readthedocs-hosted.com/en/latest/how-to/get-package-source/#pull-pkg) offers several ways to specify the version or state of the package you want to retrieve.  
+For this exercise, we will use the simplest approach:
+
+```bash
+pull-lp-source hello
+```
+
+### Initialize Git repository
+
+Initialize a Git repository in the package source directory to track all changes from this point onward.
+Example:
+
+```bash
+cd hello-2.10
+git init
+```
+
+From now on, try to commit each step individually for easier tracking and review.

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+hello (2.10-5ubuntuplucky2) plucky; urgency=medium
+
+  * Target Ubuntu version is 'plucky' 
+
+ -- Carles Sole Grau <selrac@carles-evert>  Sat, 26 Jul 2025 22:45:54 +0200
+
+hello (2.10-5selracnoble1) noble; urgency=medium
+
+  * Install 'testing.sh' in '/usr/bin' and throw to STDOUT a prompt message during installation
+
+ -- Carles Sole Grau <carlessg11@gmail.com>  Sat, 26 Jul 2025 21:59:05 +0200
+
 hello (2.10-5) unstable; urgency=medium
 
   * Add autopkgtest dependency on make. Closes: #1103293.

--- a/debian/files
+++ b/debian/files
@@ -1,0 +1,1 @@
+hello_2.10-5ubuntuplucky2_source.buildinfo devel optional

--- a/debian/install
+++ b/debian/install
@@ -1,0 +1,1 @@
+debian/testing.sh /usr/bin

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+# Output to STDOUT ('>&1' is not needed in this case)
+echo "this is a test from Carles Solé Grau"
+
+# Hook for debhelper (even if not needed) to avoid a warning
+#DEBHELPER#
+
+exit 0

--- a/debian/testing.sh
+++ b/debian/testing.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Use '>&2' to redirect output to STDERR
+echo "this is a test from Carles Solé Grau" >&2


### PR DESCRIPTION
Please pick one existed Debian package from the Ubuntu archive and implement the following changes:

1. Download the source code of that Debian package.
2. Add an executable bash script called “testing.sh”
3. When executing the testing.sh will echo “this is a test from Carles Solé Grau ” on the standard error (STDERR).  
   - Please echo the string “this is a test from Carles Solé Grau” during the Debian package installation time.
4. Push all of your change to a public git repository (e.g. launchpad git, Github or GitLab)
5. dput the source change to your ppa on the launchpad.
6. Install your package from your ppa.
7. Paste the message printed during the installation via standard out (STDOUT)
   - The string “this is a test from Carles Solé Grau” is expected.
8. Paste the executing result of  `dpkg -S testing.sh; testing.sh`
   - The string “this is a test from Carles Solé Grau” is expected.
9. Capture the issues and tasks that you experienced for this exercise. Please submit the following result in a PDF file
   - url of the git repo
   - url of the launchpad ppa
   - Please write down the steps that can be a reference guide for the next engineer who is new to this task.
   - Include the output of the installation and testing.sh This is an example of  executing result for your reference: https://pastebin.ubuntu.com/p/hZ4sH647Jt/